### PR TITLE
Update DownloadActivity.java

### DIFF
--- a/src/main/java/de/storchp/opentracks/osmplugin/DownloadActivity.java
+++ b/src/main/java/de/storchp/opentracks/osmplugin/DownloadActivity.java
@@ -369,7 +369,7 @@ public class DownloadActivity extends BaseActivity {
             this.extractMapFromZIP = extractMapFromZIP;
         }
 
-        abstract public Uri getDirectoryUri();
+        public abstract Uri getDirectoryUri();
 
         public int getOverwriteMessageId() {
             return overwriteMessageId;


### PR DESCRIPTION
The current implementation of the method getDirectoryUri() in the codebase violates the Java Language Specification regarding the order of modifiers. According to the Java convention, modifiers should be arranged in a specific order for clarity and consistency. This issue aims to reorder the modifiers of the method to comply with the Java Language Specification.