### PR TITLE
Merge pull request from HWJFish/C1_deliverable_AS

### DIFF
--- a/src/main/java/de/storchp/opentracks/osmplugin/dashboardapi/TrackPoint.java
+++ b/src/main/java/de/storchp/opentracks/osmplugin/dashboardapi/TrackPoint.java
@@ -25,7 +25,7 @@ public class TrackPoint {
     public static final String SPEED = "speed";
     public static final double PAUSE_LATITUDE = 100.0;
 
-    public static final String[] PROJECTION_V1 = {
+    protected static final String[] PROJECTION_V1 = {
             ID,
             TRACKID,
             LATITUDE,


### PR DESCRIPTION
Title : Make this member "protected"

Description of Technical Debt
Member "PROJECTION_V1" is declared "Public" "Static" "Final". Public access modifier makes the static member "PROJECTION_V1" visible everywhere.

Member Name
PROJECTION_V1

Location
File: TrackPoint.java
Path: src\main\java\de\storchp\opentracks\osmplugin\dashboardapi\TrackPoint.java

Solution: Changing the access modifier from "public" to "protected" for member "PROJECTION_V1".

Benefit: It will reduce the visibility of the member variable "PROJECTION_V1" and enforce the use of getters for accessing the member thus following the best programming practice.